### PR TITLE
setup-makefiles.sh now skips file if not exist

### DIFF
--- a/setup-makefiles.sh
+++ b/setup-makefiles.sh
@@ -40,6 +40,10 @@ for FILE in `egrep -v '(^#|^$)' proprietary-files.txt`; do
   if [ $COUNT = "0" ]; then
     LINEEND=""
   fi
+  if [ ! -f ../../../$OUTDIR/proprietary/$FILE ]; then
+      echo "remote object /system/$FILE not found, skipping"
+      continue
+  fi
   echo "  $OUTDIR/proprietary/$FILE:system/$FILE$LINEEND" >> $MAKEFILE
 done
 


### PR DESCRIPTION
Hi. I have an Asia version of HTC /vendor/ folder, so some files which described in `proprietary-files.txt` not found.

setup-makefiles.sh should skip this cases and don't make config for skipped files.

Change-Id: I95d771f82ba0a13244e63f6857e25d042a89a2b1
